### PR TITLE
Sort out poss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.4.0",
         "@types/node": "^16.11.21",
-        "@types/react": "^17.0.38",
         "@types/react-csv": "^1.1.2",
-        "@types/react-dom": "^17.0.11",
         "@types/react-router-dom": "^5.3.3",
         "firebase": "^9.6.4",
         "rc-table": "^7.22.2",
@@ -26,8 +24,8 @@
         "react-responsive": "^9.0.0-beta.6",
         "react-router-dom": "^6.2.1",
         "react-scripts": "^5.0.0",
-        "react-select": "^5.7.0",
-        "react-switch": "^6.1.0",
+        "react-select": "^5.8.0",
+        "react-switch": "^7.0.0",
         "react-table": "^7.7.0",
         "react-table-sticky": "^1.1.3",
         "styled-components": "^5.3.6",
@@ -35,8 +33,10 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/react": "^18.2.46",
+        "@types/react-dom": "^18.2.18",
         "@types/react-select": "^5.0.1",
-        "@types/react-table": "^7.7.9",
+        "@types/react-table": "^7.7.19",
         "@types/styled-components": "^5.1.23"
       }
     },
@@ -4323,9 +4323,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "version": "18.2.46",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.46.tgz",
+      "integrity": "sha512-nNCvVBcZlvX4NU1nRRNV/mFl1nNRuTuslAJglQsq+8ldXe5Xv0Wd2f7WTE3jOxhLH2BFfiZGC6GCp+kHQbgG+w==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -4341,9 +4341,10 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
-      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
+      "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4378,9 +4379,9 @@
       }
     },
     "node_modules/@types/react-table": {
-      "version": "7.7.9",
-      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.9.tgz",
-      "integrity": "sha512-ejP/J20Zlj9VmuLh73YgYkW2xOSFTW39G43rPH93M4mYWdMmqv66lCCr+axZpkdtlNLGjvMG2CwzT4S6abaeGQ==",
+      "version": "7.7.19",
+      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.19.tgz",
+      "integrity": "sha512-47jMa1Pai7ily6BXJCW33IL5ghqmCWs2VM9s+h1D4mCaK5P4uNkZOW3RMMg8MCXBvAJ0v9+sPqKjhid0PaJPQA==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -14414,9 +14415,9 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.0.tgz",
-      "integrity": "sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -14434,9 +14435,9 @@
       }
     },
     "node_modules/react-switch": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-6.1.0.tgz",
-      "integrity": "sha512-cOwQkxtHCOGtoK0KN3kZBPTQjt8P1TTpaor+TS0AJRLfFBIRkgjVIUCwAfvVlW32Bi1BK333rk9y/14suD38SA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-7.0.0.tgz",
+      "integrity": "sha512-KkDeW+cozZXI6knDPyUt3KBN1rmhoVYgAdCJqAh7st7tk8YE6N0iR89zjCWO8T8dUTeJGTR0KU+5CHCRMRffiA==",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
@@ -20571,9 +20572,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
-      "version": "17.0.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
-      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "version": "18.2.46",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.46.tgz",
+      "integrity": "sha512-nNCvVBcZlvX4NU1nRRNV/mFl1nNRuTuslAJglQsq+8ldXe5Xv0Wd2f7WTE3jOxhLH2BFfiZGC6GCp+kHQbgG+w==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -20589,9 +20590,10 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
-      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "version": "18.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
+      "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -20625,9 +20627,9 @@
       }
     },
     "@types/react-table": {
-      "version": "7.7.9",
-      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.9.tgz",
-      "integrity": "sha512-ejP/J20Zlj9VmuLh73YgYkW2xOSFTW39G43rPH93M4mYWdMmqv66lCCr+axZpkdtlNLGjvMG2CwzT4S6abaeGQ==",
+      "version": "7.7.19",
+      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.19.tgz",
+      "integrity": "sha512-47jMa1Pai7ily6BXJCW33IL5ghqmCWs2VM9s+h1D4mCaK5P4uNkZOW3RMMg8MCXBvAJ0v9+sPqKjhid0PaJPQA==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -27898,9 +27900,9 @@
       }
     },
     "react-select": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.0.tgz",
-      "integrity": "sha512-lJGiMxCa3cqnUr2Jjtg9YHsaytiZqeNOKeibv6WF5zbK/fPegZ1hg3y/9P1RZVLhqBTs0PfqQLKuAACednYGhQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -27914,9 +27916,9 @@
       }
     },
     "react-switch": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-6.1.0.tgz",
-      "integrity": "sha512-cOwQkxtHCOGtoK0KN3kZBPTQjt8P1TTpaor+TS0AJRLfFBIRkgjVIUCwAfvVlW32Bi1BK333rk9y/14suD38SA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-7.0.0.tgz",
+      "integrity": "sha512-KkDeW+cozZXI6knDPyUt3KBN1rmhoVYgAdCJqAh7st7tk8YE6N0iR89zjCWO8T8dUTeJGTR0KU+5CHCRMRffiA==",
       "requires": {
         "prop-types": "^15.7.2"
       }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^16.11.21",
-    "@types/react": "^17.0.38",
     "@types/react-csv": "^1.1.2",
-    "@types/react-dom": "^17.0.11",
     "@types/react-router-dom": "^5.3.3",
     "firebase": "^9.6.4",
     "rc-table": "^7.22.2",
@@ -22,8 +20,8 @@
     "react-responsive": "^9.0.0-beta.6",
     "react-router-dom": "^6.2.1",
     "react-scripts": "^5.0.0",
-    "react-select": "^5.7.0",
-    "react-switch": "^6.1.0",
+    "react-select": "^5.8.0",
+    "react-switch": "^7.0.0",
     "react-table": "^7.7.0",
     "react-table-sticky": "^1.1.3",
     "styled-components": "^5.3.6",
@@ -57,8 +55,10 @@
     ]
   },
   "devDependencies": {
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
     "@types/react-select": "^5.0.1",
-    "@types/react-table": "^7.7.9",
+    "@types/react-table": "^7.7.19",
     "@types/styled-components": "^5.1.23"
   }
 }

--- a/src/components/FirebaseProvider.tsx
+++ b/src/components/FirebaseProvider.tsx
@@ -40,7 +40,7 @@ const FirebaseProvider = ({children, men}: IProvider) => {
             accGame: game.val().accGame,
             game: game.key!.replace(/_/g, ' '),
             stats: {
-              lineups, players: parsePlayers(lineups)
+              lineups, players: parsePlayers(lineups), count: 1
             }
             
           });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import {gameData, group, seasonData} from '../types';
 import Switch from 'react-switch';
 import '../App.css';
 import {Lineup} from '../lineupClass';
-import {HeaderStyle} from '../styles/header'
+import {Filter, HeaderStyle} from '../styles/header';
 
 interface iProps {
   games: gameData[];
@@ -14,12 +14,14 @@ interface iProps {
   selectedStat: string;
   finderActive: boolean;
   selectedGroup: string;
-  changeGroup: Dispatch<SetStateAction<group>>
+  changeGroup: Dispatch<SetStateAction<group>>;
   changeYear: (picked: string) => void;
   changeGame: Dispatch<SetStateAction<number>>;
   changeStat: Dispatch<SetStateAction<string>>;
   changeShowFinder: Dispatch<SetStateAction<boolean>>;
   changeFinderActive: () => void;
+  filter: boolean;
+  setFilter: Dispatch<SetStateAction<boolean>>;
 }
 interface gameChoice {
   label: string;
@@ -56,11 +58,11 @@ const statOptions: statChoice[] = [
     value: 'shooting',
   },
 ];
-const groupOptions:groupChoice[] = [
+const groupOptions: groupChoice[] = [
   {value: 'lineups', label: 'Lineups'},
   {value: 'players', label: 'Players'},
-  {value: 'yearly', label: 'Year to Year'}
-]
+  {value: 'yearly', label: 'Year to Year'},
+];
 
 //custom control compononet for select
 const Control = (props: any) => {
@@ -86,6 +88,8 @@ const Header = ({
   changeStat,
   changeShowFinder,
   changeFinderActive,
+  filter,
+  setFilter,
 }: iProps) => {
   const [gameOptions, setGameOptions] = useState<gameChoice[]>([]);
   const [yearOptions, setyearOptions] = useState<yearChoice[]>([]);
@@ -104,13 +108,14 @@ const Header = ({
         value: year,
       }))
       .sort((a, b) => {
-        const yearA = +a.value.slice(0,4)
-        const yearB = +b.value.slice(0,4);
-        return yearB-yearA
+        const yearA = +a.value.slice(0, 4);
+        const yearB = +b.value.slice(0, 4);
+        return yearB - yearA;
       });
     setyearOptions(yearOptions);
   }, [years]);
   return (
+    <div style = {{'paddingBottom': '10px'}}>
     <HeaderStyle>
       <div className="headerYearControls">
         <div className="selectContainer">
@@ -143,9 +148,14 @@ const Header = ({
       </div>
       <div className="headerGameControls">
         {finderActive && (
-          <div className="gameInfo" style = {{display:'flex', flexFlow: 'column'}}>
+          <div
+            className="gameInfo"
+            style={{display: 'flex', flexFlow: 'column'}}
+          >
             <div className="totals">Lineup Finder</div>
-            <button className = 'back' onClick={changeFinderActive}>Exit Finder</button>
+            <button className="back" onClick={changeFinderActive}>
+              Exit Finder
+            </button>
           </div>
         )}
         {!finderActive && (
@@ -164,6 +174,7 @@ const Header = ({
             )}
           </div>
         )}
+        
         <div className="selectContainer">
           <Select<gameChoice>
             options={gameOptions}
@@ -214,7 +225,7 @@ const Header = ({
           />
         </div>
         <div className="playerSwitch">
-        <Select<groupChoice>
+          <Select<groupChoice>
             options={groupOptions}
             value={groupOptions.find((x) => x.value === selectedGroup)}
             onChange={(picked) =>
@@ -225,7 +236,7 @@ const Header = ({
             className="group select"
             isSearchable={false}
             isClearable={false}
-            isDisabled = {finderActive}
+            isDisabled={finderActive}
             getOptionLabel={(option) => option.label}
             getOptionValue={(option) => option.value}
             styles={{
@@ -239,6 +250,19 @@ const Header = ({
         </div>
       </div>
     </HeaderStyle>
+    {selectedGame < 0 && (
+          <Filter>
+            <label style = {{margin: '0px 5px'}}>Poss Limit</label>
+              <Switch
+                checked={filter}
+                onChange={(checked) => setFilter(checked)}
+                height={20}
+                width = {35}
+                handleDiameter={18}
+              />
+          </Filter>
+        )}
+    </div>
   );
 };
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -115,153 +115,166 @@ const Header = ({
     setyearOptions(yearOptions);
   }, [years]);
   return (
-    <div style = {{'paddingBottom': '10px'}}>
-    <HeaderStyle>
-      <div className="headerYearControls">
-        <div className="selectContainer">
-          <Select
-            options={yearOptions}
-            onChange={(picked) =>
-              picked
-                ? changeYear(picked.value)
-                : console.log('no option selected')
-            }
-            isClearable={false}
-            value={yearOptions.find((x) => x.value === selectedYear)}
-            getOptionLabel={(option) => option.label}
-            getOptionValue={(option) => option.value}
-            className="select year"
-            isSearchable={false}
-            isDisabled={finderActive || selectedGroup === 'yearly'}
-            styles={{
-              control: (provided) => ({...provided, padding: '5px 0px'}),
-              valueContainer: (provided) => ({...provided, marginTop: 'auto'}),
-            }}
-            components={{
-              Control: (props) => <Control {...props} title="Season" />,
-            }}
-          />
-        </div>
-        <div className="headerFinder">
-          <button onClick={() => changeShowFinder(true)}>Search Lineups</button>
-        </div>
-      </div>
-      <div className="headerGameControls">
-        {finderActive && (
-          <div
-            className="gameInfo"
-            style={{display: 'flex', flexFlow: 'column'}}
-          >
-            <div className="totals">Lineup Finder</div>
-            <button className="back" onClick={changeFinderActive}>
-              Exit Finder
+    <div style={{paddingBottom: '10px'}}>
+      <HeaderStyle>
+        <div className="headerYearControls">
+          <div className="selectContainer">
+            <Select
+              options={yearOptions}
+              onChange={(picked) =>
+                picked
+                  ? changeYear(picked.value)
+                  : console.log('no option selected')
+              }
+              isClearable={false}
+              value={yearOptions.find((x) => x.value === selectedYear)}
+              getOptionLabel={(option) => option.label}
+              getOptionValue={(option) => option.value}
+              className="select year"
+              isSearchable={false}
+              isDisabled={finderActive || selectedGroup === 'yearly'}
+              styles={{
+                control: (provided) => ({...provided, padding: '5px 0px'}),
+                valueContainer: (provided) => ({
+                  ...provided,
+                  marginTop: 'auto',
+                }),
+              }}
+              components={{
+                Control: (props) => <Control {...props} title="Season" />,
+              }}
+            />
+          </div>
+          <div className="headerFinder">
+            <button onClick={() => changeShowFinder(true)}>
+              Search Lineups
             </button>
           </div>
-        )}
-        {!finderActive && (
-          <div className="gameInfo">
-            {selectedGame === -2 ? (
-              <div className="totals">Season Total</div>
-            ) : selectedGame === -1 ? (
-              <div className="totals">ACC Total</div>
-            ) : (
-              <div className="score">
-                <div>Wake Forest: {games[selectedGame].score.wake}</div>
-                <div>
-                  {games[selectedGame].game}: {games[selectedGame].score.opp}
+        </div>
+        <div className="headerGameControls">
+          {finderActive && (
+            <div
+              className="gameInfo"
+              style={{display: 'flex', flexFlow: 'column'}}
+            >
+              <div className="totals">Lineup Finder</div>
+              <button className="back" onClick={changeFinderActive}>
+                Exit Finder
+              </button>
+            </div>
+          )}
+          {!finderActive && (
+            <div className="gameInfo">
+              {selectedGame === -2 ? (
+                <div className="totals">Season Total</div>
+              ) : selectedGame === -1 ? (
+                <div className="totals">ACC Total</div>
+              ) : (
+                <div className="score">
+                  <div>Wake Forest: {games[selectedGame].score.wake}</div>
+                  <div>
+                    {games[selectedGame].game}: {games[selectedGame].score.opp}
+                  </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
+          )}
+
+          <div className="selectContainer">
+            <Select<gameChoice>
+              options={gameOptions}
+              value={gameOptions.find((x) => x.value === selectedGame)}
+              onChange={(picked) =>
+                picked
+                  ? changeGame(picked.value)
+                  : console.log('No option selected')
+              }
+              className="game select"
+              isSearchable={false}
+              isClearable={false}
+              isDisabled={finderActive}
+              getOptionLabel={(option) => option.label}
+              getOptionValue={(option) => option.value.toFixed()}
+              styles={{
+                control: (provided) => ({...provided, padding: '5px 0px'}),
+                valueContainer: (provided) => ({
+                  ...provided,
+                  marginTop: 'auto',
+                }),
+              }}
+              components={{
+                Control: (props) => <Control {...props} title="Game" />,
+              }}
+            />
           </div>
-        )}
-        
-        <div className="selectContainer">
-          <Select<gameChoice>
-            options={gameOptions}
-            value={gameOptions.find((x) => x.value === selectedGame)}
-            onChange={(picked) =>
-              picked
-                ? changeGame(picked.value)
-                : console.log('No option selected')
-            }
-            className="game select"
-            isSearchable={false}
-            isClearable={false}
-            isDisabled={finderActive}
-            getOptionLabel={(option) => option.label}
-            getOptionValue={(option) => option.value.toFixed()}
-            styles={{
-              control: (provided) => ({...provided, padding: '5px 0px'}),
-              valueContainer: (provided) => ({...provided, marginTop: 'auto'}),
-            }}
-            components={{
-              Control: (props) => <Control {...props} title="Game" />,
-            }}
-          />
         </div>
-      </div>
-      <div className="headerStatControls">
-        <div className="selectController">
-          <Select<statChoice>
-            options={statOptions}
-            value={statOptions.find((x) => x.value === selectedStat)}
-            onChange={(picked) =>
-              picked
-                ? changeStat(picked.value)
-                : console.log('No option selected')
-            }
-            className="stat select"
-            isSearchable={false}
-            isClearable={false}
-            getOptionLabel={(option) => option.label}
-            getOptionValue={(option) => option.value}
-            styles={{
-              control: (provided) => ({...provided, padding: '5px 0px'}),
-              valueContainer: (provided) => ({...provided, marginTop: 'auto'}),
-            }}
-            components={{
-              Control: (props) => <Control {...props} title="Stat Type" />,
-            }}
-          />
+        <div className="headerStatControls">
+          <div className="selectController">
+            <Select<statChoice>
+              options={statOptions}
+              value={statOptions.find((x) => x.value === selectedStat)}
+              onChange={(picked) =>
+                picked
+                  ? changeStat(picked.value)
+                  : console.log('No option selected')
+              }
+              className="stat select"
+              isSearchable={false}
+              isClearable={false}
+              getOptionLabel={(option) => option.label}
+              getOptionValue={(option) => option.value}
+              styles={{
+                control: (provided) => ({...provided, padding: '5px 0px'}),
+                valueContainer: (provided) => ({
+                  ...provided,
+                  marginTop: 'auto',
+                }),
+              }}
+              components={{
+                Control: (props) => <Control {...props} title="Stat Type" />,
+              }}
+            />
+          </div>
+          <div className="playerSwitch">
+            <Select<groupChoice>
+              options={groupOptions}
+              value={groupOptions.find((x) => x.value === selectedGroup)}
+              onChange={(picked) =>
+                picked
+                  ? changeGroup(picked.value)
+                  : console.log('No option selected')
+              }
+              className="group select"
+              isSearchable={false}
+              isClearable={false}
+              isDisabled={finderActive}
+              getOptionLabel={(option) => option.label}
+              getOptionValue={(option) => option.value}
+              styles={{
+                control: (provided) => ({...provided, padding: '5px 0px'}),
+                valueContainer: (provided) => ({
+                  ...provided,
+                  marginTop: 'auto',
+                }),
+              }}
+              components={{
+                Control: (props) => <Control {...props} title="Group" />,
+              }}
+            />
+          </div>
         </div>
-        <div className="playerSwitch">
-          <Select<groupChoice>
-            options={groupOptions}
-            value={groupOptions.find((x) => x.value === selectedGroup)}
-            onChange={(picked) =>
-              picked
-                ? changeGroup(picked.value)
-                : console.log('No option selected')
-            }
-            className="group select"
-            isSearchable={false}
-            isClearable={false}
-            isDisabled={finderActive}
-            getOptionLabel={(option) => option.label}
-            getOptionValue={(option) => option.value}
-            styles={{
-              control: (provided) => ({...provided, padding: '5px 0px'}),
-              valueContainer: (provided) => ({...provided, marginTop: 'auto'}),
-            }}
-            components={{
-              Control: (props) => <Control {...props} title="Group" />,
-            }}
-          />
-        </div>
-      </div>
-    </HeaderStyle>
-    {selectedGame < 0 && (
-          <Filter>
-            <label style = {{margin: '0px 5px'}}>Poss Limit</label>
-              <Switch
-                checked={filter}
-                onChange={(checked) => setFilter(checked)}
-                height={20}
-                width = {35}
-                handleDiameter={18}
-              />
-          </Filter>
-        )}
+      </HeaderStyle>
+      <Filter>
+        <label style={{margin: '0px 5px'}}>Poss Limit</label>
+        <Switch
+          checked={filter}
+          onChange={(checked) => setFilter(checked)}
+          height={20}
+          width={35}
+          handleDiameter={18}
+          disabled={selectedGame >= 0}
+        />
+      </Filter>
     </div>
   );
 };

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -24,7 +24,7 @@ interface iProps {
 }
 
 const Table = ({data, type, onClick, filter, count}: iProps) => {
-  const tableData = useMemo<Lineup[]>(() => data.filter((x)=>x.possessions > count || !filter), [data, count, filter]);
+  const tableData = useMemo<Lineup[]>(() => data.filter((x)=>x.possessions >= count || !filter), [data, count, filter]);
   const isMobile = useMediaQuery({maxWidth: '767px'});
 
   const tableColumns = useMemo<Column<Lineup>[]>(() => {

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -18,11 +18,13 @@ import styled from 'styled-components';
 interface iProps {
   data: Lineup[];
   type: string;
-  onClick? : ()=>void
+  onClick? : ()=>void;
+  filter: boolean;
+  count: number;
 }
 
-const Table = ({data, type, onClick}: iProps) => {
-  const tableData = useMemo<Lineup[]>(() => data, [data]);
+const Table = ({data, type, onClick, filter, count}: iProps) => {
+  const tableData = useMemo<Lineup[]>(() => data.filter((x)=>x.possessions > count || !filter), [data, count, filter]);
   const isMobile = useMediaQuery({maxWidth: '767px'});
 
   const tableColumns = useMemo<Column<Lineup>[]>(() => {
@@ -38,7 +40,7 @@ const Table = ({data, type, onClick}: iProps) => {
       default:
         return total(isMobile);
     }
-  }, [type]);
+  }, [type, isMobile]);
   const defaultColumn = useMemo(
     () => ({
       // When using the useFlexLayout:

--- a/src/styles/header.ts
+++ b/src/styles/header.ts
@@ -5,9 +5,10 @@ export const HeaderStyle = styled.div`
   height: auto;
   width: 100%;
   display: flex;
+  flex-direction: row wrap;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 10px;
+  
 
   .headerGameControls {
     display: flex;
@@ -104,6 +105,10 @@ export const HeaderStyle = styled.div`
   .selectContainer {
     display: flex;
   }
+  .switch{
+    color: white;
+    
+  }
   @media screen and (max-width: 850px) {
     .playerSwitch button,
     .headerFinder button {
@@ -160,3 +165,10 @@ export const HeaderStyle = styled.div`
     }
   }
 `;
+
+export const Filter = styled.div`
+  color: white;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface gameData {
 export interface gameStats{
   lineups: Lineup[];
   players: Lineup[];
+  count: number;
 }
 
 export interface seasonData {

--- a/src/util/getLatestYear.ts
+++ b/src/util/getLatestYear.ts
@@ -8,6 +8,6 @@ export const getLatestYear = (data:totalData) : string =>{
     const yearB = +b.slice(0,4);
     return yearB - yearA
   })
-  console.log(sorted)
+  //console.log(sorted)
   return sorted
 }

--- a/src/util/parseGames.ts
+++ b/src/util/parseGames.ts
@@ -19,7 +19,8 @@ export const parseData = (games: gameData[], conference: boolean): gameStats => 
   });
   return ({
     lineups: lineupData,
-    players: parsePlayers(lineupData)
+    players: parsePlayers(lineupData),
+    count: gameData.length
   });
 };
 

--- a/src/util/tableSetup.tsx
+++ b/src/util/tableSetup.tsx
@@ -18,7 +18,7 @@ const sortNumbers = (
   desc?:boolean
 ): number => {
   const isDesc = desc ? desc : false;
-  console.log(isDesc)
+  //console.log(isDesc)
   const a = +rowA.values[id];
   const b = +rowB.values[id];
     //take care of dividing by 0 for percentages
@@ -39,7 +39,7 @@ export const total = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Lineup',
     accessor: 'players',
-    Cell: ({value}) => value.replace(/-/g, '\n'),
+    Cell: ({value}) => <>{value.replace(/-/g, '\n')}</>,
     className: 'pre',
     disableSortBy: true,
     sticky: 'left',
@@ -54,7 +54,7 @@ export const total = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Time',
     accessor: 'time',
-    Cell: ({value}) => fixTime(value),
+    Cell: ({value}) => <>{fixTime(value)}</>,
     width: isMobile ? 25 : 50,
     sortDescFirst: true,
     sortType: sortNumbers,
@@ -233,7 +233,7 @@ export const total = (isMobile: boolean): Array<Column<Lineup>> => [
       //   Header: '3P%',
       //   accessor: 'threePercentFor',
       //   sortDescFirst: true, sortType: sortNumbers,
-      //   Cell: ({value}) => value.toFixed(2),
+      //   Cell: ({value}) => <>{value.toFixed(2)}</>,
       //   Footer: (info) => {
       //     const total = useMemo(
       //       () =>
@@ -448,7 +448,7 @@ export const total = (isMobile: boolean): Array<Column<Lineup>> => [
       //   Header: '2P%',
       //   accessor: 'twoPercentAgainst',
       //   sortDescFirst: true, sortType: sortNumbers,
-      //   Cell: ({value}) => value.toFixed(2),
+      //   Cell: ({value}) => <>{value.toFixed(2)}</>,
       //   Footer: (info) => {
       //     const total = useMemo(
       //       () =>
@@ -499,7 +499,7 @@ export const total = (isMobile: boolean): Array<Column<Lineup>> => [
       //   Header: '3P%',
       //   accessor: 'threePercentAgainst',
       //   sortDescFirst: true, sortType: sortNumbers,
-      //   Cell: ({value}) => value.toFixed(2),
+      //   Cell: ({value}) => <>{value.toFixed(2)}</>,
       //   Footer: (info) => {
       //     const total = useMemo(
       //       () =>
@@ -592,7 +592,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Lineup',
     accessor: 'players',
-    Cell: ({value}) => value.replace(/-/g, '\n'),
+    Cell: ({value}) => <>{value.replace(/-/g, '\n')}</>,
     className: 'pre',
     sticky: 'left',
     width: isMobile ? 55 : 140,
@@ -607,7 +607,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Time',
     accessor: 'time',
-    Cell: ({value}) => fixTime(value),
+    Cell: ({value}) => <>{fixTime(value)}</>,
     width: isMobile ? 20 : 60,
     sortDescFirst: true,
     sortType: sortNumbers,
@@ -623,7 +623,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Pts',
     accessor: 'netPoints',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -641,7 +641,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'DRb',
     accessor: 'netDRebounds',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -660,7 +660,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'ORb',
     accessor: 'netORebounds',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -679,7 +679,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: '2PM',
     accessor: 'netMadeTwos',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -698,7 +698,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: '2PA',
     accessor: 'netAttemptedTwos',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -717,7 +717,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: '3PM',
     accessor: 'netMadeThrees',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -736,7 +736,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: '3PA',
     accessor: 'netAttemptedThrees',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -755,7 +755,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Pnt',
     accessor: 'netPaint',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -774,7 +774,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: '2nd',
     accessor: 'netSecond',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -793,7 +793,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Ast',
     accessor: 'netAssists',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -812,7 +812,7 @@ export const net = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'TO',
     accessor: 'netTurnovers',
-    Cell: ({value}) => format.format(value),
+    Cell: ({value}) => <>{format.format(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
 
@@ -834,7 +834,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Lineup',
     accessor: 'players',
-    Cell: ({value}) => value.replace(/-/g, '\n'),
+    Cell: ({value}) => <>{value.replace(/-/g, '\n')}</>,
     className: 'pre',
     disableSortBy: true,
     width: isMobile ? 55 : 140,
@@ -849,7 +849,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Poss',
     accessor: 'possessions',
-    Cell: ({value})=>Math.round(value),
+    Cell: ({value})=><>{Math.round(value)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -909,7 +909,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
     Header: 'ORB%',
     accessor: 'oRebPercent',
     disableSortBy: false,
-    Cell: ({value}) => value.toFixed(2),
+    Cell: ({value}) => <>{value.toFixed(2)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -931,7 +931,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
     Header: 'DRB%',
     accessor: 'dRebPercent',
     disableSortBy: false,
-    Cell: ({value}) => value.toFixed(2),
+    Cell: ({value}) => <>{value.toFixed(2)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -953,7 +953,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'AST %',
     accessor: 'assistPerFG',
-    Cell: ({value}) => value.toFixed(2),
+    Cell: ({value}) => <>{value.toFixed(2)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -974,7 +974,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'A/P',
     accessor: 'assistsPerPoss',
-    Cell: ({value}) => value.toFixed(2),
+    Cell: ({value}) => <>{value.toFixed(2)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -995,7 +995,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'A/TO',
     accessor: 'assistTurnoverRatio',
-    Cell: ({value}) => value.toFixed(2),
+    Cell: ({value}) => <>{value.toFixed(2)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -1016,7 +1016,7 @@ export const advanced = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'TO/P',
     accessor: 'turnoversPerPoss',
-    Cell: ({value}) => value.toFixed(2),
+    Cell: ({value}) => <>{value.toFixed(2)}</>,
     sortDescFirst: true,
     sortType: sortNumbers,
     Footer: (info) => {
@@ -1040,7 +1040,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
   {
     Header: 'Lineup',
     accessor: 'players',
-    Cell: ({value}) => value.replace(/-/g, '\n'),
+    Cell: ({value}) => <>{value.replace(/-/g, '\n')}</>,
     className: 'pre',
     disableSortBy: true,
     width: isMobile ? 55 : 150,
@@ -1095,7 +1095,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
       {
         Header: 'FG%',
         accessor: 'fgPercentFor',
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         sortDescFirst: true,
         sortType: sortNumbers,
         Footer: (info) => {
@@ -1153,7 +1153,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
       {
         Header: '2P%',
         accessor: 'twoPercentFor',
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         sortDescFirst: true,
         sortType: sortNumbers,
         Footer: (info) => {
@@ -1210,7 +1210,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
         accessor: 'threePercentFor',
         sortDescFirst: true,
         sortType: sortNumbers,
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         Footer: (info) => {
           const total = useMemo(() => {
             const made = info.rows.reduce(
@@ -1229,7 +1229,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
       {
         Header: 'eFG%',
         accessor: 'eFGFor',
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         sortDescFirst: true,
         sortType: sortNumbers,
         Footer: (info) => {
@@ -1257,7 +1257,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
         accessor: 'threeARFor',
         sortDescFirst: true,
         sortType: sortNumbers,
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         Footer: (info) => {
           const total = useMemo(() => {
             const threes = info.rows.reduce(
@@ -1319,7 +1319,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
       {
         Header: 'FG%',
         accessor: 'fgPercentAgainst',
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         sortDescFirst: true,
         sortType: sortNumbers,
         Footer: (info) => {
@@ -1377,7 +1377,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
       {
         Header: '2P%',
         accessor: 'twoPercentAgainst',
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         sortDescFirst: true,
         sortType: sortNumbers,
         Footer: (info) => {
@@ -1434,7 +1434,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
         accessor: 'threePercentAgainst',
         sortDescFirst: true,
         sortType: sortNumbers,
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         Footer: (info) => {
           const total = useMemo(() => {
             const made = info.rows.reduce(
@@ -1453,7 +1453,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
       {
         Header: 'eFG%',
         accessor: 'eFGAgainst',
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         sortDescFirst: true,
         sortType: sortNumbers,
         Footer: (info) => {
@@ -1481,7 +1481,7 @@ export const shooting = (isMobile: boolean): Array<Column<Lineup>> => [
         accessor: 'threeARAgainst',
         sortDescFirst: true,
         sortType: sortNumbers,
-        Cell: ({value}) => value.toFixed(2),
+        Cell: ({value}) => <>{value.toFixed(2)}</>,
         Footer: (info) => {
           const total = useMemo(() => {
             const threes = info.rows.reduce(


### PR DESCRIPTION
Adds the ability to filter out lineups that haven't met the minimum possession requirements, which has been set to 1 possession per game for the time being. Users can use the slider to remove or add the lineups. For individual games, the minimum possessions limit is 1. 